### PR TITLE
Replace xmp tag with pre tag

### DIFF
--- a/index.html
+++ b/index.html
@@ -270,7 +270,7 @@
         </dl>
 
         <p>This type is used to represent all the currently available MIDI input ports as a MapClass-like interface.  This enables 
-          <xmp>   // to tell how many entries there are:
+          <pre>    // to tell how many entries there are:
     var numberOfMIDIInputs = inputs.size;
 
     // add each of the ports to a &lt;select&gt; box
@@ -285,7 +285,7 @@
       var opt = document.createElement("option");
       opt.text = input.name;
       document.getElementById("inputportselector").add(opt);
-    }</xmp>
+    }</pre>
       </section>
 
 
@@ -309,7 +309,7 @@
         </dl>
 
         <p>This type is used to represent all the currently available MIDI output ports as a MapClass-like interface.  This enables 
-          <xmp>   // to tell how many entries there are:
+          <pre>    // to tell how many entries there are:
     var numberOfMIDIOutputs = inputs.size;
 
     // add each of the ports to a &lt;select&gt; box
@@ -324,7 +324,7 @@
       var opt = document.createElement("option");
       opt.text = input.name;
       document.getElementById("inputportselector").add(opt);
-    }</xmp>
+    }</pre>
       </section>
 
 


### PR DESCRIPTION
Since xmp is obsoleted in HTML5, let's use pre instead of xmp.
Also, this fixes the problem that '&lt;' and '&gt;' didn't work inside xmp tag.
