### PR TITLE
MIDIOutputMap.get should return MIDIOutput

### DIFF
--- a/index.html
+++ b/index.html
@@ -302,7 +302,7 @@
           <dd>iterator for map entries; the passed arrays would contain [ MIDIKeyType, MIDIOutput ]</dd>
           <dt>function values( void function ( MIDIOutput ) )</dt>
           <dd>Iterator for values</dd>
-          <dt>MIDIInput get( DOMString key )</dt>
+          <dt>MIDIOutput get( DOMString key )</dt>
           <dd>Getter for a particular input</dd>  
           <dt>boolean has( DOMString key )</dt>
           <dd>Returns true if the keyed port currently exists and is available.</dd>


### PR DESCRIPTION
It looks just a typo, but it should be MIDIOutput.
