### PR TITLE
MIDIAccess.inputs/outputs should be readonly

### DIFF
--- a/index.html
+++ b/index.html
@@ -381,10 +381,10 @@
 
       <dl title="interface MIDIAccess : EventTarget"
           class="idl">
-        <dt>attribute MIDIInputMap inputs</dt>
+        <dt>readonly attribute MIDIInputMap inputs</dt>
         <dd>The MIDI input ports available to the system.</dd>
 
-        <dt>attribute MIDIOutputMap outputs</dt>
+        <dt>readonly attribute MIDIOutputMap outputs</dt>
         <dd>The MIDI output ports available to the system.</dd>
 
         <dt>attribute EventHandler onconnect</dt>


### PR DESCRIPTION
Otherwise users can overwrite it like MIDIACcess.inputs = new myMap().
