### PR TITLE
A returned Promise may be rejected with AbortError

### DIFF
--- a/index.html
+++ b/index.html
@@ -225,7 +225,7 @@
 
                 <li><p><em><b>failure</b></em>: Let <var>error</var> be a new <code><a>DOMError</a></code>.
                   This should be of type <code>"SecurityError"</code> if the
-                  user or their security settings denied the application from creating a MIDIAccess instance with the requested options, <code>"InvalidStateError"</code> if the underlying systems raise any errors, or otherwise it should be of type <code>"NotSupportedError"</code>.</p></li>
+                  user or their security settings denied the application from creating a MIDIAccess instance with the requested options, <code>"AbortError"</code> if the page is going to be closed for a user navigation, <code>"InvalidStateError"</code> if the underlying systems raise any errors, or otherwise it should be of type <code>"NotSupportedError"</code>.</p></li>
                 <li><p>Call <var>resolver</var>'s <code>reject(value)</code> method with <var>error</var> as value argument.</p></li>
               </ol>
 


### PR DESCRIPTION
When a user is going to close the page, pending Promise may be
rejected with AbortError.
