### PR TITLE
Outputs would probably come from outputs variable

### DIFF
--- a/index.html
+++ b/index.html
@@ -308,7 +308,7 @@
 
         <p>This type is used to represent all the currently available MIDI output ports as a MapClass-like interface.  This enables 
           <pre>    // to tell how many entries there are:
-    var numberOfMIDIOutputs = inputs.size;
+    var numberOfMIDIOutputs = outputs.size;
 
     // add each of the ports to a &lt;select&gt; box
     outputs.values( function( port ) {


### PR DESCRIPTION
I'd kind of like to just show it being accessed from `midiAccess.outputs` but perhaps the purpose of this example it so show it in isolation.
