### PR TITLE
size attribute must be unsigned long

### DIFF
--- a/index.html
+++ b/index.html
@@ -253,7 +253,7 @@
 
         <dl title="interface [MapClass(DOMString, MIDIPort)] MIDIInputMap"
             class="idl">
-          <dt>attribute readonly int size</dt>
+          <dt>readonly attribute unsigned long size</dt>
           <dd>The number of available MIDI input ports at the current time.</dd>
           <dt>function keys( void function ( DOMString ) )</dt>
           <dd>iterator for keys</dd>
@@ -292,7 +292,7 @@
 
         <dl title="interface [MapClass(DOMString, MIDIPort)] MIDIOutputMap"
             class="idl">
-          <dt>attribute readonly int size</dt>
+          <dt>readonly attribute unsigned long size</dt>
           <dd>The number of available MIDI output ports at the current time.</dd>
           <dt>function keys( void function ( DOMString ) )</dt>
           <dd>iterator for keys</dd>


### PR DESCRIPTION
size should not be signed value, and WebIDL does not allow to use
int for Number. long is the right type.
also readonly should be declared before the attribute.
