### PR TITLE
MIDIMessageEventInit and MIDIConnectionEventInit should inherit from EventInit

### DIFF
--- a/index.html
+++ b/index.html
@@ -663,7 +663,7 @@
       </dl>
       <section>
         <h2 id="MIDIMessageEventInit"><a>MIDIMessageEventInit</a> Interface</h2>
-        <dl title="dictionary MIDIMessageEventInit"
+        <dl title="dictionary MIDIMessageEventInit : EventInit"
             class="idl">
           <dt>double receivedTime</dt>
           <dd>
@@ -691,7 +691,7 @@
 
       <section>
         <h2 id="MIDIConnectionEventInit"><a>MIDIConnectionEventInit</a> Interface</h2>
-        <dl title="dictionary MIDIConnectionEventInit"
+        <dl title="dictionary MIDIConnectionEventInit : EventInit"
             class="idl">
           <dt>MIDIPort port</dt>
           <dd>


### PR DESCRIPTION
These event inits should inherit from EventInit[1], like other event inits do(e.g. [2]). Otherwise, `bubbles` and `cancelable` attributes aren't initialized correctly.

[1] https://dom.spec.whatwg.org/#interface-event
[2] https://dom.spec.whatwg.org/#customevent
