### PR TITLE
Normalize markup in section headings

### DIFF
--- a/index.html
+++ b/index.html
@@ -252,7 +252,7 @@
       </section>
 
       <section>
-        <h3 id="MIDIInputMap"><dfn>MIDIInputMap</dfn> Interface</h3>
+        <h3 id="MIDIInputMap"><a>MIDIInputMap</a> Interface</h3>
         
         <dl class="idl"
             title="callback ForEachCallback = void">
@@ -301,7 +301,7 @@
 
 
       <section>
-        <h3 id="MIDIOutputMap"><dfn>MIDIOutputMap</dfn> Interface</h3>
+        <h3 id="MIDIOutputMap"><a>MIDIOutputMap</a> Interface</h3>
 
         <dl class="idl"
             title="callback ForEachCallback = void">
@@ -350,7 +350,7 @@
 
 
       <section>
-        <h2>MIDISuccessCallback</h2>
+        <h2><a>MIDISuccessCallback</a></h2>
 
         <dl class="idl"
             title="callback MIDISuccessCallback = void">
@@ -378,9 +378,7 @@
       </section>
 
       <section>
-        <h2>
-          MIDIErrorCallback
-        </h2>
+        <h2><a>MIDIErrorCallback</a></h2>
 
         <dl class="idl"
             title="callback MIDIErrorCallback = void">


### PR DESCRIPTION
The section headings for the MIDIInputMap and MIDIOutputMap interfaces, as well as the headings for MIDISuccessCallback and MIDIErrorCallback, used &lt;dfn>Name&lt;/dfn> instead of &lt;a>Name&lt;/a> which is used in other section headings. This affects for instance the appearance of the names in the TOC, making them harder to find there.
