### PR TITLE
Introduce MIDIPortState

### DIFF
--- a/index.html
+++ b/index.html
@@ -406,36 +406,21 @@
         <dt>readonly attribute MIDIOutputMap outputs</dt>
         <dd>The MIDI output ports available to the system.</dd>
 
-        <dt>attribute EventHandler onconnect</dt>
+        <dt>attribute EventHandler onstatechange</dt>
         <dd>
-          <p>The handler called when a new port is connected.</p>
+          <p>The handler called when a new port is connected or an existing port changes the state attribute.</p>
           <p>This <a>event handler</a>, of type <code><a href=
-            "#event-midiaccess-connect">MIDIConnectionEvent</a></code>,
+            "#event-midiaccess-statechange">MIDIConnectionEvent</a></code>,
             MUST be supported by all objects implementing the
             <code><a>MIDIAccess</a></code> interface.
           </p>
-          <p id="event-midiaccess-connect">
-              Whenever a previously unavailable MIDI port becomes available for use, the user agent SHOULD run the following steps:</p>
+          <p id="event-midiaccess-statechange">
+              Whenever a previously unavailable MIDI port becomes available for use, or an existing port changes the state attribute,
+              the user agent SHOULD run the following steps:</p>
           <ol>
-            <li>Let <code>port</code> be the <code><a>MIDIPort</a></code> corresponding to the newly-available port.</li>
+            <li>Let <code>port</code> be the <code><a>MIDIPort</a></code> corresponding to the newly-available, or the existing port.</li>
             <li>Let <code>event</code> be a newly constructed <code><a>MIDIConnectionEvent</a></code>, with the <code>port</code> attribute set to the port.</li>
-            <li>Fire an event named <code><a href="#event-midiaccess-connect">connect</a></code>at the <code>MIDIAccess</code>, using the <code>event</code> as the event object.</li>
-          </ol>
-        </dd>
-
-        <dt>attribute EventHandler ondisconnect</dt>
-        <dd>
-          <p>The handler called when a previously-available port is disconnected.</p>
-          <p>This <a>event handler</a>, of type <code><a href=
-            "#event-midiacces-disconnect">MIDIConnectionEvent</a></code>,
-            MUST be supported by all objects implementing the
-            <code><a>MIDIAccess</a></code> interface.</p>
-          <p id="event-midiaccess-disconnect">
-              Whenever a previously available MIDI port becomes unavailable for use, the user agent SHOULD run the following steps:</p>
-          <ol>
-            <li>Let <code>port</code> be the <code><a>MIDIPort</a></code> corresponding to the previously-available port.</li>
-            <li>Let <code>event</code> be a newly constructed <code><a>MIDIConnectionEvent</a></code>, with the <code>port</code> attribute set to the port.</li>
-            <li>Fire an event named <code><a href="#event-midiaccess-disconnect">disconnect</a></code>at the <code>MIDIAccess</code>, using the <code>event</code> as the event object.</li>
+            <li>Fire an event named <code><a href="#event-midiaccess-statechange">statechange</a></code>at the <code>MIDIAccess</code>, using the <code>event</code> as the event object.</li>
           </ol>
         </dd>
 
@@ -449,7 +434,7 @@
 
       <p>This interface represents a MIDI input or output port.</p>
 
-      <dl class="idl" title='enum MIDIPortType'>
+      <dl class="idl" title="enum MIDIPortType">
         <dt>input</dt>
         <dd>
           If a MIDIPort is an input port, the type member MUST be this value.
@@ -457,6 +442,21 @@
         <dt>output</dt>
         <dd>
           If a MIDIPort is an output port, the type member MUST be this value.
+        </dd>
+      </dl>
+
+      <dl class="idl" title="enum MIDIPortState">
+        <dt>disconnected</dt>
+        <dd>
+          If a device that MIDIPort represents is disconnected, the state member MUST be this value.
+        </dd>
+        <dt>connected</dt>
+        <dd>
+          If a device that MIDIPort represents is connected, and is not opened, the state member MUST be this value.
+        </dd>
+        <dt>opened</dt>
+        <dd>
+          If a device that MIDIPort represents is connected and opened, the state member MUST be this value.
         </dd>
       </dl>
 
@@ -507,20 +507,21 @@
         <dd>
           <p>The version of the port.</p>
         </dd>
-        <dt>attribute EventHandler ondisconnect</dt>
+        <dt>readonly attribute MIDIPortState state</dt>
+        <dt>attribute EventHandler onstatechange</dt>
         <dd>
-          <p>The handler called when a previously-available port is disconnected.</p>
+          <p>The handler called when an existing port changes the state attribute.</p>
           <p>This <a>event handler</a>, of type <code><a href=
-            "#event-midiport-disconnect">disconnect</a></code>,
+            "#event-midiport-statechange">statechange</a></code>,
             MUST be supported by all objects implementing
             <code><a>MIDIPort</a></code> interface.
           </p>
         </dd>
       </dl>
 
-      <p id="event-midiport-disconnect">
+      <p id="event-midiport-statechange">
           Whenever the MIDI port corresponding to the
-          <code><a>MIDIPort</a></code> becomes unavailable for use, the user agent SHOULD
+          <code><a>MIDIPort</a></code> changes the state attribute, the user agent SHOULD
           run the following steps:
         </p>
 
@@ -542,12 +543,11 @@
           <li>
             <p>
               Fire an event named <code><a
-              href="#event-midiport-disconnect">disconnect</a></code>
+              href="#event-midiport-statechange">statechange</a></code>
               at the <code>port</code>, using the <code>event</code> as the event object.
             </p>
           </li>
         </ol>
-
 
       <section>
         <h3 id="MIDIInput"><a>MIDIInput</a> Interface</h3>


### PR DESCRIPTION
This change reflects discussion at #105.
It introduces MIDIPortState attribute to MIDIPort and integrates onconnect and ondisconnect events into onstatechange event.
We may want to have more concrete description on state change in the future.
