### PR TITLE
Update returning type of requestMIDIAccess() to be Promise<MIDIAccess>

### DIFF
--- a/index.html
+++ b/index.html
@@ -168,7 +168,7 @@
 
           <dl class="idl"
               title="partial interface Navigator">
-            <dt>Promise requestMIDIAccess(optional MIDIOptions options )</dt>
+            <dt>Promise&lt;MIDIAccess&gt; requestMIDIAccess( optional MIDIOptions options )</dt>
             <dd>
               <p>
                 When invoked, returns a Promise object representing a request for access to MIDI devices on the user's system.


### PR DESCRIPTION
To be aligned with MIDIPort.open() and close(), returning value of
requestMIDIAccess() should not be simply Promise, but Promise<MIDIAccess>.
