### PR TITLE
port should be defined for already opened or closed cases

### DIFF
--- a/index.html
+++ b/index.html
@@ -568,6 +568,8 @@
             <li><p>Return <var>promise</var> and run the following steps 
               asynchronously.</p></li>
 
+            <li><p>Let <var>port</var> be the given <code><a>MIDIPort</a></code> object.</p></li>
+
             <li><p>If the device is already open (e.g. open() has already been
                 called on this MIDIPort, or the port has been implicitly 
                 opened), jump to the step labeled <em>opened</em> below.</p></li>
@@ -578,10 +580,7 @@
                 <em>failure</em> below.  If the device available and access is
                 obtained, continue the following steps.</p></li>
 
-            <li><p><em><b>success</b></em>: Let <var>port</var> be the given 
-              <code><a>MIDIPort</a></code> object.</p></li>
-
-            <li><p>Change the <code>state</code> attribute of the MIDIPort to 
+            <li><p><em><b>success</b></em>: Change the <code>state</code> attribute of the MIDIPort to 
               <code>"opened"</code>, and enqueue a new <code><a>MIDIConnectionEvent</a></code> 
               to the <code><a href="#event-midiaccess-statechange">statechange</a></code> 
               handler of the <code><a>MIDIAccess</a></code> and to the 
@@ -632,6 +631,8 @@
             <li><p>Return <var>promise</var> and run the following steps 
               asynchronously.</p></li>
 
+            <li><p>Let <var>port</var> be the given <code><a>MIDIPort</a></code> object.</p></li>
+
             <li><p>If the device is already closed (the state is already 
                 "connected" - e.g. the port has not yet been implicitly or explictly
                 opened, or close() has already been called on this MIDIPort), 
@@ -644,10 +645,7 @@
             <li><p>Close access to the port in the underlying system, and
               release any blocking resources to the underlying system.</p></li>
 
-            <li><p><em><b>success</b></em>: Let <var>port</var> be the given 
-              <code><a>MIDIPort</a></code> object.</p></li>
-
-            <li><p>Change the <code>state</code> attribute of the MIDIPort to 
+            <li><p><em><b>success</b></em>: Change the <code>state</code> attribute of the MIDIPort to 
               <code>"closed"</code>, and enqueue a new <code><a>MIDIConnectionEvent</a></code> 
               to the <code><a href="#event-midiaccess-statechange">statechange</a></code> 
               handler of the <code><a>MIDIAccess</a></code> and to the 


### PR DESCRIPTION
In the current algorithm for open() and close(), port is defined
only for success cases, but not defined for already opened or closed
cases that skip the step defines the port. To define it for both cases,
let move the definition to an early place.
