### PR TITLE
MIDIPortState does not have "closed" state

### DIFF
--- a/index.html
+++ b/index.html
@@ -646,7 +646,7 @@
               release any blocking resources to the underlying system.</p></li>
 
             <li><p><em><b>success</b></em>: Change the <code>state</code> attribute of the MIDIPort to 
-              <code>"closed"</code>, and enqueue a new <code><a>MIDIConnectionEvent</a></code> 
+              <code>"connected"</code>, and enqueue a new <code><a>MIDIConnectionEvent</a></code> 
               to the <code><a href="#event-midiaccess-statechange">statechange</a></code> 
               handler of the <code><a>MIDIAccess</a></code> and to the 
               <code><a href="#event-midiport-statechange">statechange</a></code> 


### PR DESCRIPTION
MIDIPortState does not have "closed" state, but "connected" is the equivalent state.
