### PR TITLE
Fix typo in close method ("connected" is not a MIDIPortConnectionState)

### DIFF
--- a/index.html
+++ b/index.html
@@ -586,7 +586,7 @@
           <p>
             Makes the MIDI device corresponding to the 
             <code><a href="#idl-def-MIDIPort">MIDIPort</a></code> explicitly 
-            unavailable (subsequently changing the state from "open" to "connected").
+            unavailable (subsequently changing the state from "open" to "closed").
             Note that successful invocation of this method will result in MIDI 
             messages no longer being delivered to MIDIMessageEvent handlers on a 
             <a>MIDIInputPort</a> (although setting a new handler will cause an 


### PR DESCRIPTION
Surely the `.close()` method on a MIDIPort changes the state from "open" to "closed", rather than to "connected"?
