### PR TITLE
Integrate with Permissions

### DIFF
--- a/index.html
+++ b/index.html
@@ -161,8 +161,8 @@
           Permissions Integration
         </h2>
         <p>
-          The Web Midi API is a [=default powerful feature=] that is identified
-          by the [=powerful feature/name=] "midi" [[Permissions]]. It defines
+          The Web Midi API is a [=powerful feature=] that is identified
+          by the [=powerful feature/name=] <a>"midi"</a>. It defines
           the following:
         </p>
         <dl>
@@ -187,9 +187,9 @@
           Permissions Policy Integration
         </h2>
         <p>
-          The Web Midi API defines a <a>policy-controlled feature</a> named
-          <dfn data-lt="midi-fp" data-lt-nodefault="">`midi`</dfn> which has a
-          <a>default allowlist</a> of `'self'` [[Permissions-Policy]].
+          The Web Midi API defines a [=policy-controlled feature=] named
+          <dfn class="permission">"midi"</dfn> which has a
+          <a>default allowlist</a> of `'self'`.
         </p>
       </section>
       <section data-dfn-for="Navigator">

--- a/index.html
+++ b/index.html
@@ -158,16 +158,9 @@
           Permissions Policy Integration
         </h2>
         <p>
-          {{requestMIDIAccess()}} is a <a>policy-controlled feature</a>, as
-          defined by [[[Permissions-Policy]]].
-        </p>
-        <p>
-          The feature name for {{requestMIDIAccess()}} is <dfn data-lt=
-          "midi-fp" data-lt-nodefault="">`midi`</dfn>.
-        </p>
-        <p>
-          The <a>default allowlist</a> for {{requestMIDIAccess()}} is
-          `"self"`.
+          The Web Midi API defines a <a>policy-controlled feature</a> named
+          <dfn data-lt="midi-fp" data-lt-nodefault="">`midi`</dfn> which has a
+          <a>default allowlist</a> of `'self'` [[!Permissions-Policy]].
         </p>
       </section>
       <section data-dfn-for="Navigator">

--- a/index.html
+++ b/index.html
@@ -155,6 +155,32 @@
       </h2>
       <section data-link-for="Navigator">
         <h2>
+          Permissions Integration
+        </h2>
+        <p data-cite="permissions">
+          The Web Midi API is a [=default powerful feature=] that is identified
+          by the [=powerful feature/name=] "midi" [[!Permissions]]. It defines
+          the following:
+        </p>
+        <dl>
+          <dt>
+            [=powerful feature/permission descriptor type=]
+          </dt>
+          <dd>
+            <pre class="idl">
+              dictionary MidiPermissionDescriptor : PermissionDescriptor {
+                boolean sysex = false;
+              };
+            </pre>
+            <p>
+              `{name: "midi", sysex: true}` is [=PermissionDescriptor/stronger than=] `{name:
+              "midi", sysex: false}`.
+            </p>
+          </dd>
+        </dl>
+      </section>
+      <section data-link-for="Navigator">
+        <h2>
           Permissions Policy Integration
         </h2>
         <p>

--- a/index.html
+++ b/index.html
@@ -31,11 +31,14 @@
         wgPatentURI: "https://www.w3.org/2004/01/pp-impl/46884/status",
         previousPublishDate: "2013-11-26",
         previousMaturity: "WD",
-        xref: "web-platform",
+        xref: {
+          profile: "web-platform",
+          specs: ["hr-time", "permissions", "permissions-policy"],
+        }
       };
     </script>
   </head>
-  <body data-cite="hr-time permissions-policy">
+  <body>
     <section id="abstract">
       <p>
         Some user agents have music devices, such as synthesizers, keyboard and
@@ -157,9 +160,9 @@
         <h2>
           Permissions Integration
         </h2>
-        <p data-cite="permissions">
+        <p>
           The Web Midi API is a [=default powerful feature=] that is identified
-          by the [=powerful feature/name=] "midi" [[!Permissions]]. It defines
+          by the [=powerful feature/name=] "midi" [[Permissions]]. It defines
           the following:
         </p>
         <dl>
@@ -186,7 +189,7 @@
         <p>
           The Web Midi API defines a <a>policy-controlled feature</a> named
           <dfn data-lt="midi-fp" data-lt-nodefault="">`midi`</dfn> which has a
-          <a>default allowlist</a> of `'self'` [[!Permissions-Policy]].
+          <a>default allowlist</a> of `'self'` [[Permissions-Policy]].
         </p>
       </section>
       <section data-dfn-for="Navigator">

--- a/index.html
+++ b/index.html
@@ -167,7 +167,7 @@
         </p>
         <p>
           The <a>default allowlist</a> for {{requestMIDIAccess()}} is
-          `["self"]`.
+          `"self"`.
         </p>
       </section>
       <section data-dfn-for="Navigator">

--- a/index.html
+++ b/index.html
@@ -176,7 +176,7 @@
         </h2>
         <pre class="idl">
             partial interface Navigator {
-              [SecureContext] 
+              [SecureContext]
               Promise &lt;MIDIAccess&gt; requestMIDIAccess(optional MIDIOptions options = {});
             };
           </pre>


### PR DESCRIPTION
As part of https://github.com/w3c/permissions/issues/263, this PR moves some of the Permissions stuff into WebMidi (so Permissions doesn't have to be a registry, but instead defines powerful features infrastructure).

It also fixes some bugs in the Permissions policy section.

cc @marcoscaceres 