### PR TITLE
Flag MidiPermissionDescriptor definition as non normative

### DIFF
--- a/index.html
+++ b/index.html
@@ -170,7 +170,7 @@
             [=powerful feature/permission descriptor type=]
           </dt>
           <dd>
-            <pre class="idl">
+            <pre class="idl exclude">
               dictionary MidiPermissionDescriptor : PermissionDescriptor {
                 boolean sysex = false;
               };


### PR DESCRIPTION
Spec prose makes it clear that the IDL is defined in the Permissions spec, but tools that crawl specs to extract things from them do not read the prose and happily think that the Web Midi API spec re-defines the dictionary.