### PR TITLE
Fixes #220 - Hook requestMIDIAccess into Permissions

### DIFF
--- a/index.html
+++ b/index.html
@@ -216,7 +216,7 @@
               devices, particularly if system exclusive access is requested. In
               some scenarios, this permission may have already been implicitly
               or explicitly granted, in which case this prompt may not appear.
-              If the user gives express permission or the call is otherwise
+              If the user gives [=express permission=] or the call is otherwise
               approved, the vended Promise is resolved. The underlying system
               may choose to allow the user to select specific MIDI interfaces
               to expose to this API (i.e. pick and choose interfaces on an

--- a/index.html
+++ b/index.html
@@ -163,29 +163,9 @@
         <p>
           The Web Midi API is a [=powerful feature=] that is identified
           by the [=powerful feature/name=] <a>"midi"</a>. It defines
-          the following:
+          the {{MidiPermissionDescriptor}}
+          [=powerful feature/permission descriptor type=].
         </p>
-        <dl>
-          <dt>
-            [=powerful feature/permission descriptor type=]
-          </dt>
-          <dd>
-            <pre class="idl exclude">
-              dictionary MidiPermissionDescriptor : PermissionDescriptor {
-                boolean sysex = false;
-                boolean software = false;
-              };
-            </pre>
-            <p>
-              `{name: "midi", sysex: true}` is [=PermissionDescriptor/stronger than=] `{name:
-              "midi", sysex: false}`.
-            </p>
-            <p>
-              `{name: "midi", software: true}` is [=PermissionDescriptor/stronger than=] `{name:
-              "midi", software: false}`.
-            </p>
-          </dd>
-        </dl>
       </section>
       <section data-link-for="Navigator">
         <h2>
@@ -204,7 +184,7 @@
         <pre class="idl">
             partial interface Navigator {
               [SecureContext]
-              Promise &lt;MIDIAccess&gt; requestMIDIAccess(optional MIDIOptions options = {});
+              Promise &lt;MIDIAccess&gt; requestMIDIAccess(optional MidiPermissionDescriptor options = {});
             };
           </pre>
         <dl>
@@ -337,18 +317,18 @@
           </dd>
         </dl>
       </section>
-      <section data-dfn-for="MIDIOptions" data-link-for="Navigator">
-        <h2 id="MIDIOptions">
-          <dfn>MIDIOptions</dfn> Dictionary
+      <section data-dfn-for="MidiPermissionDescriptor" data-link-for="Navigator">
+        <h2 id="MidiPermissionDescriptor">
+          {{MidiPermissionDescriptor}} Dictionary
         </h2>
         <p>
           This dictionary contains optional settings that may be provided to
           the {{requestMIDIAccess()}} request.
         </p>
-        <pre class="idl">
-          dictionary MIDIOptions {
-            boolean sysex;
-            boolean software;
+        <pre class="idl exclude">
+          dictionary MidiPermissionDescriptor : PermissionDescriptor {
+            boolean sysex = false;
+            boolean software = false;
           };
         </pre>
         <dl>
@@ -367,6 +347,10 @@
               will throw exceptions if the user tries to send system exclusive
               messages, and will silently mask out any system exclusive
               messages received on the port.
+            </p>
+            <p>
+              `{name: "midi", sysex: true}` is [=PermissionDescriptor/stronger than=] `{name:
+              "midi", sysex: false}`.
             </p>
           </dd>
           <dt>
@@ -389,6 +373,10 @@
               synthesizer support is desired but not required - software
               synthesizers may be disabled when MIDI hardware device access is
               allowed.
+            </p>
+            <p>
+              `{name: "midi", software: true}` is [=PermissionDescriptor/stronger than=] `{name:
+              "midi", software: false}`.
             </p>
           </dd>
         </dl>

--- a/index.html
+++ b/index.html
@@ -193,8 +193,9 @@
           </dt>
           <dd>
             <p>
-              When invoked, returns a Promise object representing a request for
-              access to MIDI devices on the user's system.
+              When invoked the {{Navigator/requestMIDIAccess()}} method returns
+              a promise that represents a request for access to MIDI devices on
+              the user's system.
             </p>
             <p>
               Requesting MIDI access SHOULD prompt the user for access to MIDI
@@ -216,106 +217,170 @@
             </p>
             <p data-link-for="Navigator">
               When the {{requestMIDIAccess()}} method is called, the user agent
-              MUST run the <dfn>algorithm to request MIDI Access</dfn>:
+              MUST run the following steps:
             </p>
             <ol>
               <li>
                 <p>
-                  Let <var>promise</var> be a new Promise object and
-                  <var>resolver</var> be its associated resolver.
+                  Let <var>promise</var> be [=a new promise=].
                 </p>
               </li>
               <li>
                 <p>
-                  Return <var>promise</var> and run the following steps
-                  asynchronously.
+                  Run the following steps [=in parallel=]:
                 </p>
               </li>
-              <li>
-                <p>
-                  Let <var>document</var> be the calling context's
-                  <a>Document</a>.
-                </p>
-              </li>
-              <li>
-                <p>
-                  If <var>document</var> is not <a>allowed to use</a> the
-                  <a>policy-controlled feature</a> named <a>midi</a>, jump to
-                  the step labeled <em>failure</em> below.
-                </p>
-              </li>
-              <li>
-                <p>
-                  Optionally, e.g. based on a previously-established user
-                  preference, for security reasons, or due to platform
-                  limitations, jump to the step labeled <em>failure</em> below.
-                </p>
-              </li>
-              <li>
-                <p>
-                  Optionally, e.g. based on a previously-established user
-                  preference, jump to the step labeled <em>success</em> below.
-                </p>
-              </li>
-              <li>
-                <p>
-                  Prompt the user in a user-agent-specific manner for
-                  permission to provide the entry script's origin with a
-                  {{MIDIAccess}} object representing control over user's MIDI
-                  devices. This prompt may be contingent upon whether system
-                  exclusive support was requested, and may allow the user to
-                  enable or disable that access.
-                </p>
-                <p>
-                  If permission is denied, jump to the step labeled
-                  <em>failure</em> below. If the user never responds, this
-                  algorithm will never progress beyond this step. If permission
-                  is granted, continue the following steps.
-                </p>
-              </li>
-              <li>
-                <p>
-                  <em><b>success</b></em>: Let <var>access</var> be a new
-                  {{MIDIAccess}} object. (It is possible to call
-                  requestMIDIAccess() multiple times; this may prompt the user
-                  multiple times, so it may not be best practice, and the same
-                  instance of MIDIAccess will not be returned each time.)
-                </p>
-              </li>
-              <li>
-                <p>
-                  Call <var>resolver</var>'s <code>accept(value)</code> method
-                  with <var>access</var> as value argument.
-                </p>
-              </li>
-              <li>
-                <p>
-                  Terminate these steps.
-                </p>
-              </li>
-              <li>
-                <p>
-                  <em><b>failure</b></em>: Let <var>error</var> be a new
-                  {{DOMException}}. This exception's .name should be
-                  {{"SecurityError"}} if the user or their security settings
-                  denied the application from creating a MIDIAccess instance
-                  with the requested options, or if the error is the result of
-                  <var>document</var> not being <a>allowed to use</a> the
-                  feature, {{"AbortError"}} if the page is going to be closed
-                  for a user navigation, {{"InvalidStateError"}} if the
-                  underlying systems raise any errors, or otherwise it should
-                  be {{"NotSupportedError"}}.
-                </p>
-              </li>
-              <li>
-                <p>
-                  Call <var>resolver</var>'s <code>reject(value)</code> method
-                  with <var>error</var> as value argument.
-                </p>
-              </li>
+              <ol>
+                <li>
+                  <p>
+                    Let <var>document</var> be the calling context's
+                    <a>Document</a>.
+                  </p>
+                </li>
+                <li>
+                  <p>
+                    If <var>document</var> is not <a>allowed to use</a> the
+                    <a>policy-controlled feature</a> named <a>"midi"</a>, then:
+                    <ol>
+                      <li>
+                        <p>
+                          [=Deny MIDI access=] with |promise| and
+                          {{"SecurityError"}}.
+                        </p>
+                      </li>
+                      <li>
+                        <p>Return |promise|.</p>
+                      </li>
+                    </ol>
+                  </p>
+                </li>
+                <li>
+                  <p>
+                    Optionally, e.g. based on a previously-established user
+                    preference, for security reasons, or due to platform
+                    limitations:
+                    <ol>
+                      <li>
+                        <p>
+                          Let |exception name| be {{"SecurityError"}} if the
+                          user or their security settings denied the application
+                          from creating a {{MIDIAccess}} instance with the
+                          requested options, {{"AbortError"}} if the
+                          page is going to be closed for a user navigation,
+                          {{"InvalidStateError"}} if the underlying systems
+                          raise any errors, or otherwise to
+                          {{"NotSupportedError"}}.
+                        </p>
+                        <li>
+                          <p>
+                            [=Deny MIDI access=] with |promise| and
+                            |exception name|.
+                          </p>
+                        </li>
+                        <li>
+                          <p>Return |promise|.</p>
+                        </li>
+                      </li>
+                    </ol>
+                  </p>
+                </li>
+                <li>
+                  <p>
+                    Optionally, e.g. based on a previously-established user
+                    preference:
+                    <ol>
+                      <li>
+                        <p>
+                          [=Grant MIDI access=] with |promise|.
+                        </p>
+                      </li>
+                      <li>
+                        <p>Return |promise|.</p>
+                      </li>
+                    </ol>
+                  </p>
+                </li>
+                <li>
+                  <p>
+                    Prompt the user in a user-agent-specific manner for
+                    permission to provide the entry script's origin with a
+                    {{MIDIAccess}} object representing control over user's MIDI
+                    devices. This prompt may be contingent upon whether system
+                    exclusive support was requested, and may allow the user to
+                    enable or disable that access:
+                    <ol>
+                      <li>
+                        <p>
+                          If permission is denied:
+                          <ol>
+                            <li>
+                              <p>
+                                [=Deny MIDI access=] with |promise| and
+                                {{"SecurityError"}}.
+                              </p>
+                            </li>
+                            <li>
+                              <p>Return |promise|.</p>
+                            </li>
+                          </ol>
+                        </p>
+                      </li>
+                      <li>
+                        <p>
+                          If permission is granted:
+                        </p>
+                          <ol>
+                            <li>
+                              <p>
+                                [=Grant MIDI access=] with |promise|.
+                              </p>
+                            </li>
+                            <li>
+                              <p>Return |promise|.</p>
+                            </li>
+                          </ol>
+                        </p>
+                      </li>
+                    </ol>
+                  </p>
+                </li>
+              </ol>
             </ol>
           </dd>
         </dl>
+        <p>
+          To <dfn>deny MIDI access</dfn> with |promise| and |exception name|,
+          run these steps:
+          <ol>
+            <li>
+              <p>Let |error| be a new {{DOMException}} with its
+              {{DOMException/name}} set to |exception name|.</p>
+            </li>
+            <li>
+              <p>[=Reject=] |promise| with |error|.</p>
+            </li>
+          </ol>
+        </p>
+        <p>
+          To <dfn>grant MIDI access</dfn> with |promise|, run these
+          steps:
+          <ol>
+            <li>
+              <p>
+                Let <var>access</var> be a new {{MIDIAccess}} object.
+              </p>
+              <p class="note">
+                It is possible to call {{Navigator/requestMIDIAccess()}}
+                multiple times; this may prompt the user multiple times, so it
+                may not be best practice, and the same instance of
+                {{MIDIAccess}} will not be returned each time.
+              </p>
+            </li>
+            <li>
+              <p>[=Resolve=] |promise| with |access|.</p>
+            </li>
+          </ol>
+        </p>
       </section>
       <section data-dfn-for="MidiPermissionDescriptor" data-link-for="Navigator">
         <h2 id="MidiPermissionDescriptor">

--- a/index.html
+++ b/index.html
@@ -198,17 +198,17 @@
             </p>
             <p>
               Requesting MIDI access SHOULD prompt the user for access to MIDI
-              devices, particularly if system exclusive access is requested. In
-              some scenarios, this permission may have already been implicitly
-              or explicitly granted, in which case this prompt may not appear.
-              If the user gives [=express permission=] or the call is otherwise
-              approved, the vended Promise is resolved. The underlying system
-              may choose to allow the user to select specific MIDI interfaces
-              to expose to this API (i.e. pick and choose interfaces on an
-              individual basis), although this is not required. The system may
-              also choose to prompt (or not) based on whether system exclusive
-              support is requested, as system exclusive access has greater
-              privacy and security implications.
+              devices, particularly if [=system exclusive=] access is requested.
+              In some scenarios, this permission may have already been
+              implicitly or explicitly granted, in which case this prompt may
+              not appear. If the user gives [=express permission=] or the call
+              is otherwise approved, the vended Promise is resolved. The
+              underlying system may choose to allow the user to select specific
+              MIDI interfaces to expose to this API (i.e. pick and choose
+              interfaces on an individual basis), although this is not required.
+              The system may also choose to prompt (or not) based on whether
+              [=system exclusive=] support is requested, as [=system exclusive=]
+              access has greater privacy and security implications.
             </p>
             <p>
               If the user declines or the call is denied for any other reason,
@@ -338,19 +338,19 @@
           <dd>
             <p>
               This member informs the system whether the ability to send and
-              receive system exclusive messages is requested or allowed on a
+              receive [=system exclusive=] messages is requested or allowed on a
               given {{MIDIAccess}} object. On the option passed to
               {{requestMIDIAccess()}}, if this member is set to true, but
-              system exclusive support is denied (either by policy or by user
-              action), the access request will fail with a {{"SecurityError"}}
-              error. If this support is not requested (and allowed), the system
-              will throw exceptions if the user tries to send system exclusive
-              messages, and will silently mask out any system exclusive
-              messages received on the port.
+              [=system exclusive=] support is denied (either by policy or by
+              user action), the access request will fail with a
+              {{"SecurityError"}} error. If this support is not requested (and
+              allowed), the system will throw exceptions if the user tries to
+              send [=system exclusive=] messages, and will silently mask out any
+              [=system exclusive=] messages received on the port.
             </p>
             <p>
-              `{name: "midi", sysex: true}` is [=PermissionDescriptor/stronger than=] `{name:
-              "midi", sysex: false}`.
+              `{name: "midi", sysex: true}` is
+              [=PermissionDescriptor/stronger than=] `{name: "midi", sysex: false}`.
             </p>
           </dd>
           <dt>
@@ -375,8 +375,8 @@
               allowed.
             </p>
             <p>
-              `{name: "midi", software: true}` is [=PermissionDescriptor/stronger than=] `{name:
-              "midi", software: false}`.
+              `{name: "midi", software: true}` is
+              [=PermissionDescriptor/stronger than=] `{name: "midi", software: false}`.
             </p>
           </dd>
         </dl>
@@ -520,8 +520,8 @@
             <dfn>sysexEnabled</dfn>
           </dt>
           <dd>
-            This attribute informs the user whether system exclusive support is
-            enabled on this MIDIAccess.
+            This attribute informs the user whether [=system exclusive=] support
+            is enabled on this MIDIAccess.
           </dd>
         </dl>
       </section>
@@ -960,9 +960,9 @@
             </li>
             <li>
               <p>
-                If the {{MIDIAccess}} did not enable system exclusive access,
-                and the message is a system exclusive message, abort this
-                process.
+                If the {{MIDIAccess}} did not enable [=system exclusive=]
+                access, and the message is a [=system exclusive=] message, abort
+                this process.
               </p>
             </li>
             <li>
@@ -1028,9 +1028,9 @@
                 a valid MIDI message, throw a <code>TypeError</code> exception.
               </p>
               <p>
-                If <var>data</var> is a system exclusive message, and the
-                {{MIDIAccess}} did not enable system exclusive access, throw an
-                <code>InvalidAccessError</code> exception.
+                If <var>data</var> is a [=system exclusive=] message, and the
+                {{MIDIAccess}} did not enable [=system exclusive=] access, throw
+                an <code>InvalidAccessError</code> exception.
               </p>
               <p>
                 If the port is <a data-lt=
@@ -1338,7 +1338,7 @@ navigator.requestMIDIAccess().then( onMIDISuccess, onMIDIFailure );</pre>
           </h3>
           <p>
             This example shows how to request access to the MIDI system,
-            including the ability to send and receive system exclusive
+            including the ability to send and receive [=system exclusive=]
             messages.
           </p>
           <pre class="example">var midi = null;  // global MIDIAccess object

--- a/index.html
+++ b/index.html
@@ -173,11 +173,16 @@
             <pre class="idl exclude">
               dictionary MidiPermissionDescriptor : PermissionDescriptor {
                 boolean sysex = false;
+                boolean software = false;
               };
             </pre>
             <p>
               `{name: "midi", sysex: true}` is [=PermissionDescriptor/stronger than=] `{name:
               "midi", sysex: false}`.
+            </p>
+            <p>
+              `{name: "midi", software: true}` is [=PermissionDescriptor/stronger than=] `{name:
+              "midi", software: false}`.
             </p>
           </dd>
         </dl>


### PR DESCRIPTION
I untangled the existing requestMIDIAccess algorithm a bit (pulling out the labelled "success" / "failure" steps) - hope that's OK. 

Still a draft, because I haven't added in any Permissions integration yet. That probably comes in step 5?