### PR TITLE
Move sotd to just after abstract

### DIFF
--- a/index.html
+++ b/index.html
@@ -94,6 +94,7 @@
         systems, such as Apple's CoreMIDI and Microsoft's Windows MIDI API.
       </p>
     </section>
+    <section id="sotd"></section>
     <section class="informative">
       <h2>
         Introduction
@@ -128,7 +129,6 @@
         General MIDI can easily be utilized through the Web MIDI API).
       </p>
     </section>
-    <section id="sotd"></section>
     <section id="conformance">
       <p>
         This specification defines conformance criteria that apply to a single


### PR DESCRIPTION
The "Status of This Document" section is apparently supposed to come right after the abstract.  Move it there instead of its current location in the introduction.