### PR TITLE
Fix links to user agent and default allowlist

### DIFF
--- a/index.html
+++ b/index.html
@@ -132,7 +132,7 @@
     <section id="conformance">
       <p>
         This specification defines conformance criteria that apply to a single
-        product: the <dfn>user agent</dfn> that implements the interfaces that
+        product: the <a>user agent</a> that implements the interfaces that
         it contains.
       </p>
       <p>
@@ -194,7 +194,7 @@
         <p>
           The Web Midi API defines a [=policy-controlled feature=] named
           <dfn class="permission">"midi"</dfn> which has a
-          <a>default allowlist</a> of `'self'`.
+          [=policy-controlled feature/default allowlist=] of `'self'`.
         </p>
       </section>
       <section data-dfn-for="Navigator">


### PR DESCRIPTION
I think the user agent link being a definition was an error, and it looks like the default allowlist reference changed since the spec was initially written.