### PR TITLE
Add test suite URI

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,6 +36,7 @@
         group: "wg/audio",
         previousPublishDate: "2013-11-26",
         previousMaturity: "WD",
+        testSuiteURI: "https://github.com/web-platform-tests/wpt/tree/master/webmidi",
         xref: {
           profile: "web-platform",
           specs: ["hr-time", "permissions", "permissions-policy"],


### PR DESCRIPTION
Link to the WPT repository for Web MIDI.  Maybe not strictly necessary, but since we have it we may as well.