### PR TITLE
Make MIDIMessageEvent data MIDIConnectionEvent port nullable

### DIFF
--- a/index.html
+++ b/index.html
@@ -1227,7 +1227,7 @@
           </h2>
           <pre class="idl">
           dictionary MIDIMessageEventInit: EventInit {
-            Uint8Array? data;
+            Uint8Array data;
           };
         </pre>
           <dl>
@@ -1301,7 +1301,7 @@
           </h2>
           <pre class="idl">
           dictionary MIDIConnectionEventInit: EventInit {
-            MIDIPort? port;
+            MIDIPort port;
           };
         </pre>
           <dl>

--- a/index.html
+++ b/index.html
@@ -1194,7 +1194,7 @@
         <pre class="idl">
         [SecureContext, Exposed=Window]
         interface MIDIMessageEvent : Event {
-          constructor(DOMString type, optional MIDIMessageEventInit eventInitDict = {});
+          constructor(DOMString type, MIDIMessageEventInit eventInitDict);
           readonly attribute Uint8Array data;
         };
       </pre>
@@ -1215,7 +1215,7 @@
           </h2>
           <pre class="idl">
           dictionary MIDIMessageEventInit: EventInit {
-            Uint8Array data;
+            required Uint8Array data;
           };
         </pre>
           <dl>
@@ -1269,7 +1269,7 @@
         <pre class="idl">
         [SecureContext, Exposed=Window]
         interface MIDIConnectionEvent : Event {
-          constructor(DOMString type, optional MIDIConnectionEventInit eventInitDict = {});
+          constructor(DOMString type, MIDIConnectionEventInit eventInitDict);
           readonly attribute MIDIPort port;
         };
       </pre>
@@ -1289,7 +1289,7 @@
           </h2>
           <pre class="idl">
           dictionary MIDIConnectionEventInit: EventInit {
-            MIDIPort port;
+            required MIDIPort port;
           };
         </pre>
           <dl>

--- a/index.html
+++ b/index.html
@@ -1206,8 +1206,8 @@
         <pre class="idl">
         [SecureContext, Exposed=Window]
         interface MIDIMessageEvent : Event {
-          constructor(DOMString type, MIDIMessageEventInit eventInitDict);
-          readonly attribute Uint8Array data;
+          constructor(DOMString type, optional MIDIMessageEventInit eventInitDict = {});
+          readonly attribute Uint8Array? data;
         };
       </pre>
         <dl>
@@ -1227,7 +1227,7 @@
           </h2>
           <pre class="idl">
           dictionary MIDIMessageEventInit: EventInit {
-            required Uint8Array data;
+            Uint8Array? data;
           };
         </pre>
           <dl>
@@ -1281,8 +1281,8 @@
         <pre class="idl">
         [SecureContext, Exposed=Window]
         interface MIDIConnectionEvent : Event {
-          constructor(DOMString type, MIDIConnectionEventInit eventInitDict);
-          readonly attribute MIDIPort port;
+          constructor(DOMString type, optional MIDIConnectionEventInit eventInitDict = {});
+          readonly attribute MIDIPort? port;
         };
       </pre>
         <dl>
@@ -1301,7 +1301,7 @@
           </h2>
           <pre class="idl">
           dictionary MIDIConnectionEventInit: EventInit {
-            required MIDIPort port;
+            MIDIPort? port;
           };
         </pre>
           <dl>


### PR DESCRIPTION
This is to fix #168 and #233.

It seems like there are two possible approaches to fixing these issues:
- One, the "correct" approach as done in this PR, is to make the constructor arguments non-optional and the fields in the dictionaries required.  This is how we handle the similar pattern in Web Audio (for example, https://webaudio.github.io/web-audio-api/#OfflineAudioCompletionEvent).
- Two, the "pragmatic" approach is to make the attributes nullable.  This is considered pragmatic because we won't have to change Chromium if we do this.

While pragmatism is generally a good thing, I would like to consider this one more time with Gecko and Chromium stakeholders before merging a change.

If it's not a lot of work to update the implementations, and if we don't expect this to break applications, it seems like making the arguments required might be a better API.  But, if we feel strongly that it's better to simply make this nullable to move forward more quickly I will modify this change to that form.