### PR TITLE
Make MIDIMessageEventInit data and MIDIConnectionEventInit port explicitly nullable

### DIFF
--- a/index.html
+++ b/index.html
@@ -1225,7 +1225,7 @@
           </h2>
           <pre class="idl">
           dictionary MIDIMessageEventInit: EventInit {
-            Uint8Array data;
+            Uint8Array? data;
           };
         </pre>
           <dl>
@@ -1299,7 +1299,7 @@
           </h2>
           <pre class="idl">
           dictionary MIDIConnectionEventInit: EventInit {
-            MIDIPort port;
+            MIDIPort? port;
           };
         </pre>
           <dl>


### PR DESCRIPTION
#252 made MIDIMessageEvent data and MIDIConnectionEvent port nullable.

Based on this comment: https://github.com/WebAudio/web-midi-api/issues/233#issuecomment-1131480459 I didn't make the init dictionary members nullable.

However, Chromium currently has these dictionary members nullable:
https://crsrc.org/c/third_party/blink/renderer/modules/webmidi/midi_connection_event_init.idl;l=11
https://crsrc.org/c/third_party/blink/renderer/modules/webmidi/midi_message_event_init.idl;l=11

And Firefox has port nullable (but not data):
https://searchfox.org/mozilla-central/source/dom/webidl/MIDIConnectionEvent.webidl#23
https://searchfox.org/mozilla-central/source/dom/webidl/MIDIMessageEvent.webidl#24

Since the intent was to codify the existing Chromium behavior, I think this means that we should make them both nullable.

This actually does make a difference, since testing in Chromium we get the current behavior:

> new MIDIMessageEvent("something", {data: null}).data
null

> new MIDIConnectionEvent("something", {port: null}).port
null

But after aligning the IDL with the current spec we get the following:

> new MIDIMessageEvent("something", {data: null}).data
VM261:1 Uncaught TypeError: Failed to construct 'MIDIMessageEvent': Failed to read the 'data' property from 'MIDIMessageEventInit': Failed to convert value to 'Uint8Array'.
    at <anonymous>:1:1

> new MIDIConnectionEvent("something", {port: null}).port
VM285:1 Uncaught TypeError: Failed to construct 'MIDIConnectionEvent': Failed to read the 'port' property from 'MIDIConnectionEventInit': Failed to convert value to 'MIDIPort'.
    at <anonymous>:1:1

@padenot especially, what do you think?