### PR TITLE
Add auto-publish.yml

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -1,0 +1,18 @@
+name: CI
+on:
+  pull_request: {}
+  push:
+    branches: [gh-pages]
+jobs:
+  main:
+    name: Build, Validate and Deploy
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: w3c/spec-prod@v2
+        with:
+          BUILD_FAIL_ON: "link-error"
+          W3C_ECHIDNA_TOKEN: ${{ secrets.ECHIDNA_TOKEN }}
+          W3C_WG_DECISION_URL: https://lists.w3.org/Archives/Public/public-audio/2024AprJun/0011.html
+          W3C_BUILD_OVERRIDE: |
+            specStatus: WD

--- a/index.html
+++ b/index.html
@@ -84,7 +84,7 @@
         controller value or sending a set of note-on messages that happen to
         represent a G#7 chord).
       </p>
-      <p data-format="markdown">
+      <p>
         To some users, "MIDI" has become synonymous with Standard MIDI Files
         and General MIDI. That is not the intent of this API; the use case of
         simply playing back a .SMF file is not within the purview of this


### PR DESCRIPTION
This will add an auto-publish workflow to keep the working draft up to date, using [spec-prod](https://github.com/w3c/spec-prod).

@svgeesus I don't have access to the secrets on the web-midi-api repository.  Could you please do the following:
- Review this pull request
- Check if we have an Echinda token already installed in the WebAudio/web-midi-api repository (https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions#accessing-your-secrets)
- If we don't have an Echinda token, could you please request one (https://github.com/w3c/echidna/wiki/Token-creation) and install it in the repository (https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions#creating-secrets-for-a-repository)?

This should fix #258 once merged.  Sorry this has taken such a long time.