### PR TITLE
Update echidna token name

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: w3c/spec-prod@v2
         with:
           BUILD_FAIL_ON: "link-error"
-          W3C_ECHIDNA_TOKEN: ${{ secrets.ECHIDNA_TOKEN }}
+          W3C_ECHIDNA_TOKEN: ${{ secrets.WEB_MIDI_ECHIDNA }}
           W3C_WG_DECISION_URL: https://lists.w3.org/Archives/Public/public-audio/2024AprJun/0011.html
           W3C_BUILD_OVERRIDE: |
             specStatus: WD


### PR DESCRIPTION
This is to fix #258.

I had the default token name set, but the actual secret was stored as WEB_MIDI_ECHIDNA instead.