### PR TITLE
Clarify that MIDIOutput.clear() should clear enqueued send data

### DIFF
--- a/index.html
+++ b/index.html
@@ -1079,7 +1079,7 @@
             </dt>
             <dd>
               <p>
-                Clears any pending send data that has not yet been sent from
+                Clears any enqueued send data that has not yet been sent from
                 the {{MIDIOutput}}'s queue. The implementation will
                 need to ensure the MIDI stream is left in a good state, so if
                 the output port is in the middle of a sysex message, a sysex


### PR DESCRIPTION
This is to fix #260.