### PR TITLE
Don't use <dfn> tag on algorithms that aren't referenced in the spec

### DIFF
--- a/index.html
+++ b/index.html
@@ -249,7 +249,7 @@
             </p>
             <p data-link-for="Navigator">
               When the {{requestMIDIAccess()}} method is called, the user agent
-              MUST run the <dfn>algorithm to request MIDI Access</dfn>:
+              MUST run the following steps:
             </p>
             <ol>
               <li>
@@ -844,7 +844,7 @@
             </p>
             <p>
               When the <code>close()</code> method is called, the user agent
-              MUST run the <dfn>algorithm to close a MIDIPort</dfn>:
+              MUST run the following steps:
             </p>
             <ol>
               <li>


### PR DESCRIPTION
This is to fix the two remaining Respec warnings.

These algorithms are wrapped in <dfn> tags, but are not referenced by anything.

Instead, just say "run the following steps:"