### PR TITLE
Move remaining examples to explainer, modernize / fix errors in examples

### DIFF
--- a/explainer.md
+++ b/explainer.md
@@ -62,6 +62,30 @@ function listInputsAndOutputs( midiAccess ) {
 }
 ```
 
+### Adding inputs and outputs to a <select> box
+
+```js
+// to tell how many entries there are:
+let numberOfMIDIInputs = inputs.size;
+
+// add each of the ports to a <select> box
+for (let input of inputs.values()) {
+  let opt = document.createElement("option");
+  opt.text = input.name;
+  document.getElementById("inputportselector").add(opt);
+}
+
+// to tell how many entries there are:
+let numberOfMIDIOutputs = outputs.size;
+
+// add each of the ports to a <select> box
+for (let output of outputs.values()) {
+  let opt = document.createElement("option");
+  opt.text = output.name;
+  document.getElementById("outputportselector").add(opt);
+}
+```
+
 ### Handling MIDI Input
 This example prints incoming MIDI messages on a single arbitrary input port to
 the console log.
@@ -69,14 +93,17 @@ the console log.
 ```js
 function onMIDIMessage( event ) {
   let str = "MIDI message received at timestamp " + event.timeStamp + "[" + event.data.length + " bytes]: ";
-  for (let i=0; i&lt;event.data.length; i++) {
+  for (let i=0; i<event.data.length; i++) {
     str += "0x" + event.data[i].toString(16) + " ";
   }
   console.log( str );
 }
 
-function startLoggingMIDIInput( midiAccess, indexOfPort ) {
-  midiAccess.inputs.forEach( function(entry) {entry.onmidimessage = onMIDIMessage;});
+function startLoggingMIDIInput( midiAccess ) {
+  for (let entry of midiAccess.inputs) {
+    let input = entry[1];
+    input.onmidimessage = onMIDIMessage;
+  }
 }
 ```
 
@@ -169,7 +196,7 @@ function onMIDIInit(midi) {
 
       let haveAtLeastOneDevice=false;
       let inputs=midiAccess.inputs.values();
-      for ( let input = inputs.next(); input &amp;& !input.done; input = inputs.next()) {
+      for ( let input = inputs.next(); input && !input.done; input = inputs.next()) {
         input.value.onmidimessage = MIDIMessageEventHandler;
         haveAtLeastOneDevice = true;
       }

--- a/explainer.md
+++ b/explainer.md
@@ -62,7 +62,7 @@ function listInputsAndOutputs( midiAccess ) {
 }
 ```
 
-### Adding inputs and outputs to a <select> box
+### Adding inputs and outputs to select boxes
 
 ```js
 // to tell how many entries there are:

--- a/index.html
+++ b/index.html
@@ -451,25 +451,9 @@
           {{MIDIInput}} instance and key is its ID.
         </p>
         <p>
-          This type is used to represent all the currently available MIDI input
-          ports. This enables:
+          This type is used to represent all the currently available [=MIDI input
+          ports=].
         </p>
-        <pre class="example">    // to tell how many entries there are:
-    let numberOfMIDIInputs = inputs.size;
-
-    // add each of the ports to a &lt;select&gt; box
-    inputs.forEach( function( port, key ) {
-      let opt = document.createElement("option");
-      opt.text = port.name;
-      document.getElementById("inputportselector").add(opt);
-    });
-
-    // or you could express in ECMAScript 6 as:
-    for (let input of inputs.values()) {
-      let opt = document.createElement("option");
-      opt.text = input.name;
-      document.getElementById("inputportselector").add(opt);
-    }</pre>
       </section>
       <section data-dfn-for="MIDIOutputMap">
         <h3 id="MIDIOutputMap">
@@ -486,24 +470,8 @@
         </p>
         <p>
           This type is used to represent all the currently available [=MIDI
-          output ports=]. This enables:
+          output ports=].
         </p>
-        <pre class="example">    // to tell how many entries there are:
-    let numberOfMIDIOutputs = outputs.size;
-
-    // add each of the ports to a &lt;select&gt; box
-    outputs.forEach( function( port, key ) {
-      let opt = document.createElement("option");
-      opt.text = port.name;
-      document.getElementById("outputportselector").add(opt);
-    });
-
-    // or you could express in ECMAScript 6 as:
-    for (let output of outputs.values()) {
-      let opt = document.createElement("option");
-      opt.text = output.name;
-      document.getElementById("outputportselector").add(opt);
-    }</pre>
       </section>
       <section data-dfn-for="MIDIAccess" data-link-for="MIDIAccess">
         <h2 id="MIDIAccess">


### PR DESCRIPTION
This is to fix #173

Just move the two remaining examples to the explainer, and only keep the ECMAScript 6 versions of the code.