### PR TITLE
Clarify what data should be sent when a port is reopened

### DIFF
--- a/index.html
+++ b/index.html
@@ -777,9 +777,9 @@
               </li>
               <li>
                 <p>
-                  If this port is an output port and has any pending data that
-                  is waiting to be sent, asynchronously begin sending that
-                  data.
+                  If this port is an output port and has any enqueued send data
+                  with timestamps in the future, asynchronously begin sending
+                  that data.
                 </p>
               </li>
               <li>
@@ -874,8 +874,8 @@
                   If the port is an input port, skip to the next step. If the
                   output port's <a data-lt="MIDIPort.state">.state</a> is not
                   <a data-lt="MIDIPortDeviceState.connected">"connected"</a>,
-                  clear all pending send data and skip to the next step. Clear
-                  any pending send data in the system with timestamps in the
+                  clear all enqueued send data and skip to the next step. Clear
+                  any enqueued send data in the system with timestamps in the
                   future, then finish sending any send messages with no
                   timestamp or with a timestamp in the past or present, prior
                   to proceeding to the next step.


### PR DESCRIPTION
This is to fix #133 

Reviewer: please consider if this is enough or if we really should add some more prose to https://webaudio.github.io/web-midi-api/#MIDIConnectionEvent