### PR TITLE
Replaced deprecated `InvalidAccessError` with `NotAllowedError`

### DIFF
--- a/index.html
+++ b/index.html
@@ -807,7 +807,7 @@
                 <p>
                   <em><b>failure</b></em>: Let <var>error</var> be a new
                   {{DOMException}}. This exception's .name should be
-                  <code>"InvalidAccessError"</code> if the port is unavailable.
+                  <code>"NotAllowedError"</code> if the port is unavailable.
                 </p>
               </li>
               <li>
@@ -1043,7 +1043,7 @@
               <p>
                 If <var>data</var> is a [=System Exclusive=] message, and the
                 {{MIDIAccess}} did not enable [=System Exclusive=] access, throw
-                an <code>InvalidAccessError</code> exception.
+                an <code>NotAllowedError</code> exception.
               </p>
               <p>
                 If the port is <a data-lt=


### PR DESCRIPTION
According to [Web IDL spec on `InvalidAccessError`](https://webidl.spec.whatwg.org/#invalidaccesserror):
> Deprecated. Use [TypeError](https://webidl.spec.whatwg.org/#exceptiondef-typeerror) for invalid arguments, "[NotSupportedError](https://webidl.spec.whatwg.org/#notsupportederror)" [DOMException](https://webidl.spec.whatwg.org/#idl-DOMException) for unsupported operations, and "[NotAllowedError](https://webidl.spec.whatwg.org/#notallowederror)" [DOMException](https://webidl.spec.whatwg.org/#idl-DOMException) for denied requests instead.

Previously, while trying to open `MIDIPort`, `"InvalidAccessError" DOMException` was thrown when...
> the device is unavailable (e.g., is already in use by another process and cannot be opened, or is disconnected)

In this case, I believe `NotAllowedError` fits well, according to its [Web IDL spec  description](https://webidl.spec.whatwg.org/#notallowederror):
> The request is not allowed by the user agent or the platform in the current context, possibly because the user denied permission.

Security and permissions reasons are only a subset of the appropriate causes, according to this definition. An attempt to `open` the port can fail. Somebody's exclusive lock on the port, or the port being disconnected, <ins>is</ins> the <ins>current context</ins> driving the platform's decision not to allow the operation.

And in the context of forbidden `.send` calls:
> If data is a [System Exclusive](https://webaudio.github.io/web-midi-api/#dfn-system-exclusive) message, and the [`MIDIAccess`](https://webaudio.github.io/web-midi-api/#dom-midiaccess) did not enable [System Exclusive](https://webaudio.github.io/web-midi-api/#dfn-system-exclusive) access, throw an `InvalidAccessError` exception.

`NotAllowedError` fits even better, because it fits an explicitly defined subset of permission errors.